### PR TITLE
Fix missing font path crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv
 NotoSansJP-VariableFont_wght.ttf
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import pygame
 import sys
 import random
+import os
 from pygame.locals import MOUSEBUTTONDOWN
 
 
@@ -39,7 +40,11 @@ def runpygame():
     ave = []
 
     # font_path
-    font_path = 'NotoSansJP-VariableFont_wght.ttf'
+    # スクリプトと同じディレクトリにあるフォントを使用する
+    font_path = os.path.join(os.path.dirname(__file__),
+                             'NotoSansJP-VariableFont_wght.ttf')
+    if not os.path.exists(font_path):
+        font_path = None
 
     # Rect
     rect = pygame.Rect(150, 200, 500, 300)


### PR DESCRIPTION
## Summary
- add `os` import and check for the custom font
- fallback to default font when the font file isn't present
- resolve relative font path and ignore `__pycache__`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684d7f7f68788327b5ab65c22ac52656